### PR TITLE
Adding support for vsixgallery.com

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ install:
   - cmd: git submodule update --init
   - cmd: nuget restore
   - ps:  .\prebuild.ps1
+  - ps: (new-object Net.WebClient).DownloadString("https://raw.github.com/madskristensen/ExtensionScripts/master/AppVeyor/vsix.ps1") | iex
 
 #---------------------------------#
 #       build configuration       #
@@ -40,7 +41,6 @@ configuration: Release
 #      artifacts configuration    #
 #---------------------------------#
 
-artifacts:
-
-  - path: YamlDotNetEditor\bin\Release\YamlDotNetEditor.vsix
-    name: VSIX Package
+after_test:
+  # Push artifacts and publish the nighly build to http://vsixgallery.com
+  - ps: Vsix-PushArtifacts .\YamlDotNetEditor\bin\*\*.vsix | Vsix-PublishToGallery


### PR DESCRIPTION
This change will do a few cool things;

1. Push artifacts without the full path in the link and with a nice description 
2. Upload the compiled .vsix file to vsixgallery.com