### PR TITLE
Added support for visual studio 2017 to fix #19

### DIFF
--- a/YamlDotNetEditor/source.extension.vsixmanifest
+++ b/YamlDotNetEditor/source.extension.vsixmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
 	<Metadata>
 		<Identity Id="YamlDotNetEditor..074a7b74-655b-409c-b5ac-a028f12d6e89" Version="1.3" Language="en-US" Publisher="Antoine Aubry" />
@@ -15,7 +15,7 @@
 		<Tags>yaml editor</Tags>
 	</Metadata>
 	<Installation>
-		<InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,15.0]" />
+		<InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,16.0)" />
 	</Installation>
 	<Dependencies>
 	</Dependencies>


### PR DESCRIPTION
Fix for #19.

VS 2017 is version 15.x. The previous version range was [11.0,15.0] which means 11.0 <= VS version <= 15.0. This failed when version 15.1 came out. I've changed this to [11.0,16.0) which means. 11.0 <= VS version < 16.0 so it will work for all updates to VS 2017 but won't work for the next major version update.